### PR TITLE
adding docker developer build with bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bazel-bin
 bazel-genfiles
 bazel-out
 bazel-old
+bazel-code
 bazel-testlogs
 bazel-vagrant
 bazel-bazel-example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:22.04
+# docker build -t old .
+RUN apt-get update && apt-get install -y curl gnupg
+RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
+    echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+RUN apt-get update && apt-get install -y bazel
+WORKDIR /code
+COPY . /code
+RUN bazel build src/main:libold.so

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # old
 
-![main brabcg](https://github.com/fzakaria/old/actions/workflows/actions.yml/badge.svg)
+![main branch](https://github.com/fzakaria/old/actions/workflows/actions.yml/badge.svg)
 
 > The Other Dynamic Linker
 
@@ -120,6 +120,7 @@ The tool generously provides the required TOML file necessary for the configurat
 This repository uses [bazel](https://docs.bazel.build/) as the build system; some familiarity is required.
 
 Once you have bazel installed, building the shared object is done as follows.
+
 ```console
 $ bazel build src/main:libold.so
 ```
@@ -129,3 +130,33 @@ You can then run the built binary with the example TOML file provided by setting
 ```console
 $ OLDAUDIT_CONFIG=./example.toml LD_AUDIT=./bazel-bin/src/main/libold.so ruby --help | head
 ```
+
+### Docker
+
+If you want to develop using a Docker container,  we provide a [Dockerfile](Dockerfile)
+with bazel ready to go! First, build the container:
+
+```bash
+$ docker build -t old .
+```
+
+You can then shell inside to use old:
+
+```bash
+$ docker run -it old
+```
+```bash
+$ apt-get install -y ruby
+$ LD_AUDIT=./bazel-bin/src/main/libold.so ruby -e "puts 'hi'"
+$ OLDAUDIT_CONFIG=./example.toml LD_AUDIT=./bazel-bin/src/main/libold.so ruby --help | head
+```
+
+or bind the present working directory (with the source code) to `/code`
+to work locally and build in the container:
+
+```bash
+$ docker run -it -v $PWD:/code old
+$ bazel build src/main:libold.so
+```
+
+Have fun!


### PR DESCRIPTION
It is nice for a project to provide a means to develop that is quick and does not require install of a lot of dependencies on the host! I tested [this container](https://docs.bazel.build/versions/3.2.0/bazel-container.html) first but I think there was an older version of Ubuntu because I hit a building error - installing per the suggested method on ubuntu 22.04 did the trick!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>